### PR TITLE
Make /logout actually invalidate tokens

### DIFF
--- a/database.py
+++ b/database.py
@@ -91,3 +91,10 @@ class Database:
                 api_key = gen_api_key(prefix)
                 cur.execute(query, (api_key,))
         return api_key
+
+    def delete_tokens(self, kthid):
+        with self._connection.cursor() as cur:
+            cur.execute('''
+                DELETE FROM tokens
+                WHERE kthid = %s
+            ''', (kthid,))


### PR DESCRIPTION
Fixes #2 

Tokens are invalidated and deleted when `/logout` is visited.
Also cleaned up `database.py` to use `with ... as`-statements everywhere a cursor is used. This will automatically close the cursor when the statement is exited.
Enabled autocommit in database connections so that commiting manually isn't needed. See https://www.psycopg.org/docs/connection.html\#connection.autocommit