### PR TITLE
Add betaspexet

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,7 +29,7 @@ def hello():
 def valid_callback(callback_url):
     if os.environ.get('DONT_VALIDATE_CALLBACK', '0') != '0':
         return True
-    return re.fullmatch("^https?://([a-zA-Z0-9]+[.])*((datasektionen)|(dsekt)|(d-?dagen)|(metaspexet))[.]se(:[1-9][0-9]*)?/.*$", callback_url) is not None
+    return re.fullmatch("^https?://([a-zA-Z0-9]+[.])*((datasektionen)|(dsekt)|(d-?dagen)|((meta|beta)spexet))[.]se(:[1-9][0-9]*)?/.*$", callback_url) is not None
 
 def upgrade_to_https(url):
     if url.startswith("https://"):


### PR DESCRIPTION
Add betaspexet.se as an approved domain. We own betaspexet.se and use it as the beta version of Haj.