### PR TITLE
Allow localhost

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,10 +29,12 @@ def hello():
 def valid_callback(callback_url):
     if os.environ.get('DONT_VALIDATE_CALLBACK', '0') != '0':
         return True
-    return re.fullmatch("^https?://([a-zA-Z0-9]+[.])*((datasektionen)|(dsekt)|(d-?dagen)|((meta|beta)spexet))[.]se(:[1-9][0-9]*)?/.*$", callback_url) is not None
+    return re.fullmatch("^https?://(([a-zA-Z0-9\-]+[.])*((datasektionen)|(dsekt)|(d-?dagen)|([bm]etaspexet))[.]se|localhost|127\.0\.0\.1)(:[1-9][0-9]*)?/.*$", callback_url) is not None
 
 def upgrade_to_https(url):
     if url.startswith("https://"):
+        return url
+    if re.fullmatch("https?://(localhost|127\.0\.0\.1)(:[1-9][0-9]*)?/.*$", url):
         return url
     if not url.startswith("http://"):
         raise ValueError("Invalid url")


### PR DESCRIPTION
Maybe there is a reason we don't currently allow localhost in this system?

There is however a reason to allow it: setting up a self trusted signed certificate for developing seems unnecessarily hard, and if using `localhost.datasektionen.se` on http, web browsers don't consider it a secure context and therefore disables a few features. These features being at least some cryptography functions, secure cookies and webrtc.

Also, since `localhost.datasektionen.se` points to `127.0.0.1`, I don't think this opens up any more attack surface than before.